### PR TITLE
docs: clarify README contribution path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We believe that education is the key to empowering people to choose better wine.
 
 Education begins with common standards around how we talk about wine - a lingua franca for the wine world. This repository contains taxonomies and guidelines for how we can talk about things like wine categorization, sensory analysis, terroir, winemaking techniques and viticulture techniques.
 
-This is a work in progress and we are always looking to evolve the taxonomies presented here. Please submit a PR for any ideas for improvement you may have, or contact paige@vinebase.com.
+This repository began as a Vinebase project and is now maintained as a personal, open-source reference for wine taxonomy work. It remains a work in progress, and contributions are welcome. Please open an issue or pull request with ideas, corrections, or additions.
 
 ## Taxonomies
 


### PR DESCRIPTION
The README now points contributors toward GitHub issues and pull requests instead of a stale Vinebase contact. It also clarifies that the repository began as a Vinebase project but is now maintained as a personal open-source reference.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
